### PR TITLE
import_from_csv to auto_detect_line_endings

### DIFF
--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -256,6 +256,8 @@ class WPCOM_Legacy_Redirector_CLI extends WP_CLI_Command {
 			WP_CLI::line( 'Processing...' );
 		}
 
+		ini_set('auto_detect_line_endings',TRUE);
+
 		global $wpdb;
 		$row = 0;
 		if ( ( $handle = fopen( $csv, "r" ) ) !== FALSE ) {


### PR DESCRIPTION
Line endings caused issues for importing CSV that resulted in incomplete imports. This allows PHP to interoperate with Macintosh systems (including \r line endings from older Macs).

Note: The php documentation mentions the possibility of a minor performance hit. Since the CSV is only two columns (not too data intenstive bytes wise), while running on modern hardware CPU's, i'm not anticipating any bottlenecks at all.